### PR TITLE
feat(frontend): implement CreateFeatureDialog component

### DIFF
--- a/frontend/app/dashboard/features/page.tsx
+++ b/frontend/app/dashboard/features/page.tsx
@@ -1,4 +1,3 @@
-// 完整可執行的 FeaturesPage 元件（ICON 區標題 + 卡片：name→icon+type + 關聯樣本數）
 "use client";
 
 import { readFeaturesFeaturesGet } from "@/app/client/sdk.gen";
@@ -19,6 +18,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { CreateFeatureDialog } from "@/components/upload-feature-dialog";
 import {
   Anchor,
   Code,
@@ -229,6 +229,9 @@ export default function FeaturesPage() {
   // 'all' 或 直接存 feature_type
   const [activeCategory, setActiveCategory] = useState<string>("all");
 
+  // Dialog state
+  const [dialogOpen, setDialogOpen] = useState(false);
+
   useEffect(() => {
     const fetchData = async () => {
       const res = await readFeaturesFeaturesGet();
@@ -237,6 +240,14 @@ export default function FeaturesPage() {
     };
     fetchData();
   }, []);
+
+  // Refresh features after creation
+  const handleCreateSuccess = async () => {
+    setLoading(true);
+    const res = await readFeaturesFeaturesGet();
+    setFeatures(res.data || []);
+    setLoading(false);
+  };
 
   // 轉為前端顯示物件，補上 samples（由 sample_ids 長度取得）
   const techniques = useMemo(() => {
@@ -285,10 +296,18 @@ export default function FeaturesPage() {
           <h2 className="text-3xl font-bold">特徵資料庫</h2>
           <p className="text-muted-foreground mt-1">管理惡意程式特徵</p>
         </div>
-        <Button className="bg-blue-600 text-white">
+        <Button
+          className="bg-blue-600 text-white"
+          onClick={() => setDialogOpen(true)}
+        >
           <Plus className="w-4 h-4 mr-2" />
           新增特徵
         </Button>
+        <CreateFeatureDialog
+          open={dialogOpen}
+          onOpenChange={setDialogOpen}
+          onCreateSuccess={handleCreateSuccess}
+        />
       </div>
 
       {/* 搜尋 */}

--- a/frontend/components/upload-feature-dialog.tsx
+++ b/frontend/components/upload-feature-dialog.tsx
@@ -1,0 +1,453 @@
+"use client";
+
+import { createFeatureRouteFeaturesPost } from "@/app/client/sdk.gen";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Binary,
+  Code2,
+  Database,
+  FileCode,
+  Loader2,
+  Shield,
+} from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+interface CreateFeatureDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreateSuccess?: () => void;
+}
+
+// MITRE ATT&CK Tactics (14 個戰術)
+const MITRE_TACTICS = [
+  { id: "TA0043", name: "Reconnaissance", description: "偵察" },
+  { id: "TA0042", name: "Resource Development", description: "資源開發" },
+  { id: "TA0001", name: "Initial Access", description: "初始存取" },
+  { id: "TA0002", name: "Execution", description: "執行" },
+  { id: "TA0003", name: "Persistence", description: "持久化" },
+  { id: "TA0004", name: "Privilege Escalation", description: "權限提升" },
+  { id: "TA0005", name: "Defense Evasion", description: "防禦規避" },
+  { id: "TA0006", name: "Credential Access", description: "憑證存取" },
+  { id: "TA0007", name: "Discovery", description: "探索" },
+  { id: "TA0008", name: "Lateral Movement", description: "橫向移動" },
+  { id: "TA0009", name: "Collection", description: "收集" },
+  { id: "TA0011", name: "Command and Control", description: "命令與控制" },
+  { id: "TA0010", name: "Exfiltration", description: "外傳" },
+  { id: "TA0040", name: "Impact", description: "影響" },
+] as const;
+
+export function CreateFeatureDialog({
+  open,
+  onOpenChange,
+  onCreateSuccess,
+}: CreateFeatureDialogProps) {
+  // Basic information
+  const [featureName, setFeatureName] = useState("");
+  const [selectedTactic, setSelectedTactic] = useState("");
+  const [behavior, setBehavior] = useState("");
+
+  // Code sections
+  const [machineCode, setMachineCode] = useState("");
+  const [assembly, setAssembly] = useState("");
+  const [pseudoC, setPseudoC] = useState("");
+
+  // YARA
+  const [yaraRule, setYaraRule] = useState("");
+
+  // Tags
+  const [tagInput, setTagInput] = useState("");
+  const [tags, setTags] = useState<string[]>([]);
+
+  // UI states
+  const [creating, setCreating] = useState(false);
+  const [success, setSuccess] = useState(false);
+
+  const resetForm = () => {
+    setFeatureName("");
+    setSelectedTactic("");
+    setBehavior("");
+    setMachineCode("");
+    setAssembly("");
+    setPseudoC("");
+    setYaraRule("");
+    setTagInput("");
+    setTags([]);
+    setSuccess(false);
+    setCreating(false);
+  };
+
+  // Add tag
+  const handleAddTag = () => {
+    const trimmedTag = tagInput.trim();
+    if (!trimmedTag) {
+      toast.error("請輸入標籤");
+      return;
+    }
+    if (tags.includes(trimmedTag)) {
+      toast.error("此標籤已存在");
+      return;
+    }
+    setTags([...tags, trimmedTag]);
+    setTagInput("");
+  };
+
+  const handleRemoveTag = (index: number) => {
+    setTags(tags.filter((_, i) => i !== index));
+  };
+
+  const handleCreate = async () => {
+    // Validation
+    if (!featureName.trim()) {
+      toast.error("請輸入特徵名稱");
+      return;
+    }
+
+    if (!selectedTactic) {
+      toast.error("請選擇 MITRE ATT&CK 戰術");
+      return;
+    }
+
+    setCreating(true);
+
+    try {
+      // Get tactic name for feature_type
+      const tacticName =
+        MITRE_TACTICS.find((t) => t.id === selectedTactic)?.name ?? "";
+
+      // Prepare data matching FeatureCreate schema
+      const featureData = {
+        feature_name: featureName.trim(),
+        feature_type: tacticName, // Use tactic name as feature_type
+        behavior: behavior.trim() || undefined,
+        machine_code: machineCode.trim() || undefined,
+        assembly: assembly.trim() || undefined,
+        pseudo_c: pseudoC.trim() || undefined,
+        yara_rule: yaraRule.trim() || undefined,
+        tags: tags.length > 0 ? tags : undefined,
+        sample_ids: [], // Empty array as required by schema
+      };
+
+      await createFeatureRouteFeaturesPost({
+        body: featureData,
+      });
+
+      toast.success("特徵建立成功！");
+      setSuccess(true);
+      setTimeout(() => {
+        resetForm();
+        onOpenChange(false);
+        onCreateSuccess?.();
+      }, 1500);
+    } catch (err) {
+      console.error("Create feature failed:", err);
+      const msg =
+        err instanceof Error ? err.message : "建立特徵失敗，請稍後再試";
+      toast.error(msg);
+      setCreating(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(newOpen) => {
+        onOpenChange(newOpen);
+        if (!newOpen && !creating) {
+          resetForm();
+        }
+      }}
+    >
+      <DialogContent className="bg-background border max-w-4xl max-h-[90vh]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-xl">
+            <Database className="w-5 h-5 text-primary" />
+            建立新特徵
+          </DialogTitle>
+          <DialogDescription>
+            建立可重用的惡意程式特徵，用於分類和識別樣本
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="overflow-y-auto max-h-[calc(90vh-200px)] pr-2">
+          <Tabs defaultValue="basic" className="w-full">
+            <TabsList className="grid w-full grid-cols-3">
+              <TabsTrigger value="basic">基本資料</TabsTrigger>
+              <TabsTrigger value="code">程式碼</TabsTrigger>
+              <TabsTrigger value="yara">YARA 規則</TabsTrigger>
+            </TabsList>
+
+            {/* Tab 1: Basic Information */}
+            <TabsContent value="basic" className="space-y-4 mt-4">
+              <div className="space-y-4">
+                {/* Feature Name */}
+                <div className="space-y-2">
+                  <Label htmlFor="feature-name">
+                    特徵名稱 <span className="text-destructive">*</span>
+                  </Label>
+                  <Input
+                    id="feature-name"
+                    value={featureName}
+                    onChange={(e) => setFeatureName(e.target.value)}
+                    placeholder="例如：字串解密函數、註冊表持久化、HTTP C2 通訊..."
+                    disabled={creating}
+                  />
+                  {/* ... */}
+                </div>
+
+                <Separator />
+
+                {/* MITRE Tactic - Single Selection */}
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <Shield className="w-4 h-4 text-muted-foreground" />
+                    <Label htmlFor="tactic">
+                      MITRE ATT&CK 戰術{" "}
+                      <span className="text-destructive">*</span>
+                    </Label>
+                  </div>
+                  <Select
+                    value={selectedTactic}
+                    onValueChange={setSelectedTactic}
+                    disabled={creating}
+                  >
+                    <SelectTrigger id="tactic">
+                      <SelectValue placeholder="選擇戰術分類" />
+                    </SelectTrigger>
+                    <SelectContent className="max-h-80">
+                      {MITRE_TACTICS.map((tactic) => (
+                        <SelectItem key={tactic.id} value={tactic.id}>
+                          <div className="flex items-center gap-2">
+                            <span className="text-xs text-muted-foreground font-mono">
+                              {tactic.id}
+                            </span>
+                            <span>{tactic.description}</span>
+                          </div>
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {selectedTactic && (
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <span className="font-mono text-xs">
+                        {selectedTactic}
+                      </span>
+                      <span>-</span>
+                      <span>
+                        {
+                          MITRE_TACTICS.find((t) => t.id === selectedTactic)
+                            ?.name
+                        }
+                      </span>
+                    </div>
+                  )}
+                  {/* ... */}
+                </div>
+
+                <Separator />
+
+                {/* Behavior Description */}
+                <div className="space-y-2">
+                  <Label htmlFor="behavior">行為描述</Label>
+                  <Textarea
+                    id="behavior"
+                    value={behavior}
+                    onChange={(e) => setBehavior(e.target.value)}
+                    placeholder="詳細描述此特徵的行為、功能或目的&#10;&#10;例如：此函數負責解密儲存在 .data 段的加密字串，使用 XOR 0x42 進行解密。解密後的字串包含 C2 伺服器位址和連線參數。"
+                    className="min-h-[150px] resize-none"
+                    disabled={creating}
+                  />
+                  {/* ... */}
+                </div>
+
+                <Separator />
+
+                {/* Tags */}
+                <div className="space-y-2">
+                  <Label htmlFor="tag-input">標籤</Label>
+                  <div className="flex gap-2">
+                    <Input
+                      id="tag-input"
+                      value={tagInput}
+                      onChange={(e) => setTagInput(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" && tagInput.trim()) {
+                          e.preventDefault();
+                          handleAddTag();
+                        }
+                      }}
+                      placeholder="輸入標籤後按 Enter"
+                      disabled={creating}
+                    />
+                    <Button
+                      type="button"
+                      onClick={handleAddTag}
+                      disabled={creating || !tagInput.trim()}
+                      variant="outline"
+                      size="icon"
+                    >
+                      <span className="sr-only">添加標籤</span>
+                      <span className="text-lg">+</span>
+                    </Button>
+                  </div>
+                  {tags.length > 0 && (
+                    <div className="flex flex-wrap gap-2 mt-2">
+                      {tags.map((tag) => (
+                        <Badge
+                          key={tag}
+                          variant="secondary"
+                          className="px-2 py-1"
+                        >
+                          <span>{tag}</span>
+                          {!creating && (
+                            <button
+                              type="button"
+                              onClick={() => handleRemoveTag(tags.indexOf(tag))}
+                              className="ml-2 hover:text-destructive transition-colors"
+                            >
+                              ×
+                            </button>
+                          )}
+                        </Badge>
+                      ))}
+                    </div>
+                  )}
+                  {/* ... */}
+                </div>
+              </div>
+            </TabsContent>
+
+            {/* Tab 2: Code */}
+            <TabsContent value="code" className="space-y-4 mt-4">
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <FileCode className="w-4 h-4 text-muted-foreground" />
+                    <Label htmlFor="pseudo-c">
+                      Pseudo C Code (IDA / Ghidra)
+                    </Label>
+                  </div>
+                  <Textarea
+                    id="pseudo-c"
+                    value={pseudoC}
+                    onChange={(e) => setPseudoC(e.target.value)}
+                    placeholder="輸入 Pseudo C 代碼&#10;例如：&#10;void decrypt_strings(void) {&#10;  char *encrypted = (char *)0x401000;&#10;  for (int i = 0; i < 100; i++) {&#10;    encrypted[i] ^= 0x42;&#10;  }&#10;}"
+                    className="font-mono text-sm min-h-[200px] resize-none"
+                    disabled={creating}
+                  />
+                </div>
+
+                <Separator />
+
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <Code2 className="w-4 h-4 text-muted-foreground" />
+                    <Label htmlFor="assembly">Assembly Code</Label>
+                  </div>
+                  <Textarea
+                    id="assembly"
+                    value={assembly}
+                    onChange={(e) => setAssembly(e.target.value)}
+                    placeholder="輸入組合語言&#10;例如：&#10;mov rax, [rbp-8]&#10;mov rdi, rax&#10;call decrypt_string"
+                    className="font-mono text-sm min-h-[150px] resize-none"
+                    disabled={creating}
+                  />
+                </div>
+
+                <Separator />
+
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <Binary className="w-4 h-4 text-muted-foreground" />
+                    <Label htmlFor="machine-code">Machine Code (Binary)</Label>
+                  </div>
+                  <Textarea
+                    id="machine-code"
+                    value={machineCode}
+                    onChange={(e) => setMachineCode(e.target.value)}
+                    placeholder="輸入機器碼（十六進位）&#10;例如：48 8B 45 F8 48 89 C7 E8 3D FF FF FF"
+                    className="font-mono text-sm min-h-[120px] resize-none"
+                    disabled={creating}
+                  />
+                </div>
+
+                {/* ... */}
+              </div>
+            </TabsContent>
+
+            {/* Tab 3: YARA */}
+            <TabsContent value="yara" className="space-y-4 mt-4">
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <FileCode className="w-4 h-4 text-muted-foreground" />
+                    <Label htmlFor="yara-rule">YARA Rule</Label>
+                  </div>
+                  <Textarea
+                    id="yara-rule"
+                    value={yaraRule}
+                    onChange={(e) => setYaraRule(e.target.value)}
+                    placeholder="輸入 YARA 規則（選填）&#10;例如：&#10;rule decrypt_function {&#10;  meta:&#10;    description = &quot;解密字串函數&quot;&#10;    &#10;  strings:&#10;    $xor_loop = { 80 34 ?? 42 }&#10;    &#10;  condition:&#10;    $xor_loop&#10;}"
+                    className="font-mono text-sm min-h-[300px] resize-none"
+                    disabled={creating}
+                  />
+                  {/* ... */}
+                </div>
+              </div>
+            </TabsContent>
+          </Tabs>
+        </div>
+
+        {/* Actions */}
+        <div className="flex gap-3 pt-4 border-t">
+          <Button
+            onClick={handleCreate}
+            disabled={
+              creating || !featureName.trim() || !selectedTactic || success
+            }
+            className="flex-1"
+          >
+            {creating ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                建立中...
+              </>
+            ) : (
+              <>
+                <Database className="mr-2 h-4 w-4" />
+                建立特徵
+              </>
+            )}
+          </Button>
+          <Button
+            onClick={() => onOpenChange(false)}
+            disabled={creating}
+            variant="outline"
+          >
+            取消
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
This pull request enhances the `FeaturesPage` in the dashboard by adding a dialog for creating new features and ensuring the feature list refreshes automatically after a new feature is added. The main changes introduce a `CreateFeatureDialog` component, handle its open/close state, and update the feature list upon successful creation.

**Feature creation workflow improvements:**

* Added the `CreateFeatureDialog` component to the page and wired it to the "新增特徵" button, allowing users to add new features via a dialog interface. [[1]](diffhunk://#diff-fe40018e0c175481c705570f0dbb8e07afaf9f1e73652dc35cc584fe95892e11R21) [[2]](diffhunk://#diff-fe40018e0c175481c705570f0dbb8e07afaf9f1e73652dc35cc584fe95892e11L288-R310)
* Introduced state management (`dialogOpen`) to control the dialog's visibility and handle user interactions for opening and closing the dialog. [[1]](diffhunk://#diff-fe40018e0c175481c705570f0dbb8e07afaf9f1e73652dc35cc584fe95892e11R232-R234) [[2]](diffhunk://#diff-fe40018e0c175481c705570f0dbb8e07afaf9f1e73652dc35cc584fe95892e11L288-R310)
* Implemented a `handleCreateSuccess` function to refresh the feature list from the backend after a new feature is created, ensuring the UI stays up-to-date. [[1]](diffhunk://#diff-fe40018e0c175481c705570f0dbb8e07afaf9f1e73652dc35cc584fe95892e11R244-R251) [[2]](diffhunk://#diff-fe40018e0c175481c705570f0dbb8e07afaf9f1e73652dc35cc584fe95892e11L288-R310)