### PR TITLE
fix(auth): add route check for /report in AuthProvider

### DIFF
--- a/frontend/components/auth/auth-provider.tsx
+++ b/frontend/components/auth/auth-provider.tsx
@@ -72,6 +72,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           if (
             pathname !== "/login" &&
             pathname !== "/register" &&
+            pathname !== "/report" &&
             pathname !== "/"
           ) {
             router.replace("/login");


### PR DESCRIPTION
This pull request makes a small update to the authentication logic in the `AuthProvider` component. Now, users can access the `/report` route without being redirected to the login page, similar to how `/login`, `/register`, and the home page are handled.