### PR TITLE
feat: add NotFound component for 404 error page

### DIFF
--- a/frontend/app/not-found.tsx
+++ b/frontend/app/not-found.tsx
@@ -1,0 +1,22 @@
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div className="flex items-center min-h-screen px-4 py-12 sm:px-6 md:px-8 lg:px-12 xl:px-16 bg-background">
+      <div className="w-full space-y-6 text-center">
+        <div className="space-y-3">
+          <h1 className="text-4xl font-bold tracking-tighter sm:text-5xl animate-bounce">
+            404
+          </h1>
+          <p className="text-muted-foreground">看起來您進入了未知的數位領域</p>
+        </div>
+        <Link href="/">
+          <Button size="lg" className="bg-primary text-primary-foreground">
+            返回網站
+          </Button>
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
This pull request adds a custom 404 "Not Found" page to the frontend of the application, providing a more user-friendly experience when users navigate to an invalid route.

User experience improvements:

* Added a new `NotFound` component in `frontend/app/not-found.tsx` that displays a styled 404 error message and a button to return to the homepage.