### PR TITLE
feat(backend): add report path to malware table

### DIFF
--- a/backend/app/alembic/versions/6f1a4737e2c1_add_report_path_to_malware.py
+++ b/backend/app/alembic/versions/6f1a4737e2c1_add_report_path_to_malware.py
@@ -1,0 +1,28 @@
+"""Add report_path column to malware table
+
+Revision ID: 6f1a4737e2c1
+Revises: 32d263976ad4
+Create Date: 2025-11-26 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "6f1a4737e2c1"
+down_revision: Union[str, None] = "32d263976ad4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "malware",
+        sa.Column("report_path", sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("malware", "report_path")

--- a/backend/app/malware/crud.py
+++ b/backend/app/malware/crud.py
@@ -61,6 +61,8 @@ def create_malware(db: Session, malware_data: MalwareCreate) -> Malware:
         family=malware_data.family,
         source=malware_data.source,
         platform=malware_data.platform,
+        mitre_ids=malware_data.mitre_ids,
+        report_path=malware_data.report_path,
         uploaded_date=datetime.utcnow(),
         updated_date=datetime.utcnow(),
         feature_count=0,
@@ -85,7 +87,15 @@ def update_malware_metadata(
     """
     更新樣本的 metadata
     """
-    updatable_fields = ["filename", "family", "source", "platform", "last_seen"]
+    updatable_fields = [
+        "filename",
+        "family",
+        "source",
+        "platform",
+        "last_seen",
+        "mitre_ids",
+        "report_path",
+    ]
 
     # 套用更新
     for f in updatable_fields:

--- a/backend/app/malware/models.py
+++ b/backend/app/malware/models.py
@@ -33,6 +33,10 @@ class MalwareBase(SQLModel):
         sa_column=Column(JSON, nullable=False, server_default=text("'[]'::json")),
         description="對應的 MITRE ATT&CK 技術 ID",
     )
+    report_path: str | None = Field(
+        default=None,
+        description="樣本 PDF 報告相對路徑",
+    )
 
     @field_validator("family", mode="before")
     @classmethod
@@ -77,6 +81,7 @@ class MalwareUpdate(SQLModel, table=False):
     platform: str | None = None
     last_seen: datetime | None = None
     mitre_ids: list[str] | None = None
+    report_path: str | None = None
 
     @field_validator("family", mode="before")
     @classmethod

--- a/backend/app/malware/routes.py
+++ b/backend/app/malware/routes.py
@@ -1,5 +1,6 @@
 import json
 import shutil
+from datetime import datetime
 from pathlib import Path
 from typing import List
 from uuid import UUID
@@ -38,7 +39,10 @@ router = APIRouter(
     prefix="/malware", tags=["Malware"], dependencies=[Depends(get_current_user_dep)]
 )
 
-SAMPLE_STORAGE_DIR = Path(__file__).resolve().parents[2] / "static" / "samples"
+STATIC_ROOT = Path(__file__).resolve().parents[2] / "static"
+SAMPLE_STORAGE_DIR = STATIC_ROOT / "samples"
+REPORT_STORAGE_DIR = STATIC_ROOT / "reports"
+REPORT_RELATIVE_DIR = Path("reports")
 
 
 def parse_mitre_ids(raw: str | None) -> list[str]:
@@ -59,6 +63,24 @@ def parse_mitre_ids(raw: str | None) -> list[str]:
 
 def parse_family(raw: str | None) -> list[str]:
     return normalize_family_values(raw)
+
+
+def store_report_pdf(sample_id: str, report: UploadFile) -> str:
+    if report.filename is None:
+        raise HTTPException(status_code=400, detail="報告檔名不可為空")
+    if not (
+        (report.content_type or "").lower() == "application/pdf"
+        or report.filename.lower().endswith(".pdf")
+    ):
+        raise HTTPException(status_code=400, detail="報告必須為 PDF 格式")
+
+    REPORT_STORAGE_DIR.mkdir(parents=True, exist_ok=True)
+    report_filename = f"{sample_id}.pdf"
+    report_file_path = REPORT_STORAGE_DIR / report_filename
+    with report_file_path.open("wb") as dest:
+        shutil.copyfileobj(report.file, dest)
+    report.file.seek(0)
+    return str(REPORT_RELATIVE_DIR / report_filename)
 
 
 @router.get(
@@ -84,10 +106,15 @@ async def upload_malware(
     family: str | None = Form(None),
     source: str | None = Form(None),
     mitre_ids: str | None = Form(None),
+    report: UploadFile | None = File(None),
     db: Session = Depends(get_session),
 ):
     # 計算 hash
     md5, sha256, size = calc_hashes_from_fileobj(file.file)
+
+    report_relative_path: str | None = None
+    if report:
+        report_relative_path = store_report_pdf(sha256, report)
 
     # 建立 DTO
     data = MalwareCreate(
@@ -99,6 +126,7 @@ async def upload_malware(
         source=source,
         platform=platform,
         mitre_ids=parse_mitre_ids(mitre_ids),
+        report_path=report_relative_path,
     )
 
     if get_by_sha256(db, sha256):
@@ -115,6 +143,8 @@ async def upload_malware(
         return create_malware(db, data)
     except RuntimeError as exc:
         file_path.unlink(missing_ok=True)
+        if report_relative_path:
+            (STATIC_ROOT / Path(report_relative_path)).unlink(missing_ok=True)
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
@@ -216,6 +246,34 @@ async def download_malware_sample(
     )
 
 
+@router.post(
+    "/{sample_id}/report",
+    summary="上傳樣本 PDF 報告",
+    response_model=MalwarePublic,
+)
+async def upload_sample_report(
+    sample_id: str,
+    report: UploadFile = File(...),
+    db: Session = Depends(get_session),
+):
+    malware = get_by_sample_id(db, sample_id)
+    if not malware:
+        raise HTTPException(status_code=404, detail="找不到樣本")
+
+    old_relative = malware.report_path
+    relative_path = store_report_pdf(sample_id, report)
+
+    if old_relative and old_relative != relative_path:
+        (STATIC_ROOT / Path(old_relative)).unlink(missing_ok=True)
+
+    malware.report_path = relative_path
+    malware.updated_date = datetime.utcnow()
+    db.add(malware)
+    db.commit()
+    db.refresh(malware)
+    return malware
+
+
 @router.get("/", summary="取得惡意軟體樣本列表", response_model=List[MalwarePublic])
 async def list_malware(
     skip: int = 0,
@@ -236,6 +294,10 @@ async def delete_malware_sample(
     if not malware:
         raise HTTPException(status_code=404, detail="找不到樣本")
 
+    report_relative = malware.report_path
     delete_malware(db, malware)
     (SAMPLE_STORAGE_DIR / sample_id).unlink(missing_ok=True)
+    if report_relative:
+        report_path = STATIC_ROOT / Path(report_relative)
+        report_path.unlink(missing_ok=True)
     return {"message": "樣本已成功刪除"}

--- a/backend/scripts/pre-start.sh
+++ b/backend/scripts/pre-start.sh
@@ -6,7 +6,7 @@ set -x
 alembic upgrade head
 
 python app/initial_data.py
-python scripts/download_motif_dataset.py
+#! python scripts/download_motif_dataset.py
 python scripts/load_malware_seeds.py
 python scripts/load_feature_seeds.py
 


### PR DESCRIPTION
This pull request introduces support for uploading, storing, and managing PDF reports associated with malware samples. It adds a new `report_path` field to the malware model and database, allows PDF report uploads during sample creation and via a new endpoint, and ensures proper cleanup of report files when samples are deleted or replaced.

**Database and Model Changes:**

* Added a new nullable `report_path` column to the `malware` table via Alembic migration, and updated the SQLModel definitions (`MalwareBase`, `MalwareUpdate`) to include the new field. [[1]](diffhunk://#diff-2780d1d6c5a7e81dbdae3076974ce9c12f2dd8098f3673085e53f419ccd04281R1-R28) [[2]](diffhunk://#diff-00c7eb09064fa419f17bec136ee75b07069b58f5e2d986b99d0a2a0fc4127e72R36-R39) [[3]](diffhunk://#diff-00c7eb09064fa419f17bec136ee75b07069b58f5e2d986b99d0a2a0fc4127e72R84)

**API and CRUD Enhancements:**

* Updated the malware creation and update logic to handle the new `report_path` field, ensuring it is stored and can be modified. [[1]](diffhunk://#diff-0a84518d4b8648dfd9a409ddc1cdafda2090425fb1c8477b73e78430351b02aeR64-R65) [[2]](diffhunk://#diff-0a84518d4b8648dfd9a409ddc1cdafda2090425fb1c8477b73e78430351b02aeL88-R98)
* Modified the malware upload endpoint to accept an optional PDF report file, validate its format, store it on disk, and save its relative path. [[1]](diffhunk://#diff-af3bc875b95b2e19bb1289159a6fce10ca4eaba09ea4e85310325ee64f299056R109-R118) [[2]](diffhunk://#diff-af3bc875b95b2e19bb1289159a6fce10ca4eaba09ea4e85310325ee64f299056R129)

**Report File Management:**

* Added a helper function `store_report_pdf` to validate, store, and return the relative path of uploaded PDF reports.
* Implemented a new endpoint (`POST /malware/{sample_id}/report`) to upload or replace a sample's PDF report, with cleanup of the old report file if replaced.
* Ensured that report files are deleted from disk when their associated malware samples are deleted.

**Other Changes:**

* Updated script comments in `pre-start.sh` to disable motif dataset download for now.