### PR TITLE
Stanley/fix/auth

### DIFF
--- a/backend/app/auth/routes.py
+++ b/backend/app/auth/routes.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends
 from fastapi.security import OAuth2PasswordRequestForm
 
 from app.core.config import settings
-from app.core.security import create_jwt_token, oauth2_scheme
+from app.core.security import create_jwt_token, extract_jwt_token, oauth2_scheme
 from app.database import SessionDep
 from app.users.models import UserPublic
 
@@ -38,3 +38,21 @@ async def get_me(session: SessionDep, token: str = Depends(oauth2_scheme)):
     user = get_current_user(session, token)
 
     return UserPublic(id=user.id, username=user.username, email=user.email)
+
+
+@router.post("/refresh", summary="刷新 JWT token", response_model=Token)
+async def refresh_token(token: str = Depends(oauth2_scheme)):
+    """
+    使用當前有效的 token 來頒發一個新的 access token。
+    注意：如果 token 已經過期，這個 endpoint 會回傳 401。前端應該在 token 過期前呼叫此端點以靜默刷新。
+    """
+    payload = extract_jwt_token(token)
+    # payload 中應包含 sub
+    sub = payload.get("sub")
+    if not sub:
+        return Token(access_token="", token_type="bearer")
+
+    expires = timedelta(minutes=settings.TOKEN_EXPIRE_MINUTES)
+    new_token = create_jwt_token({"sub": str(sub)}, expires)
+
+    return Token(access_token=new_token, token_type="bearer")

--- a/frontend/components/auth/auth-provider.tsx
+++ b/frontend/components/auth/auth-provider.tsx
@@ -2,10 +2,14 @@
 
 import { getMeAuthMeGet } from "@/app/client";
 import type { UserPublic } from "@/app/client/types.gen";
+import appConfig from "@/lib/config";
+
 import {
   clearAuthToken,
+  decodeJwtPayload,
   initApiClient,
   loadAuthTokenFromStorage,
+  refreshAuthToken,
 } from "@/lib/api";
 import { usePathname, useRouter } from "next/navigation";
 import React, {
@@ -103,28 +107,87 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   // 設定自動刷新 token（每 25 分鐘刷新一次，token 有效期為 30 分鐘）
   useEffect(() => {
+    // Schedule refresh using token expiry if user is signed in
     if (user && typeof window !== "undefined") {
-      // 清除舊的計時器
+      // Clear old timer
       if (refreshTimerRef.current) {
-        clearInterval(refreshTimerRef.current);
+        clearTimeout(refreshTimerRef.current);
+        refreshTimerRef.current = null;
       }
 
-      // 設定新的計時器：每 25 分鐘檢查一次
-      refreshTimerRef.current = setInterval(
-        () => {
-          console.log("Auto-refreshing token...");
-          checkAuth(true); // silent refresh
-        },
-        25 * 60 * 1000,
-      ); // 25 分鐘
+      const token =
+        localStorage.getItem(appConfig.auth.tokenStorageKey) ||
+        sessionStorage.getItem(appConfig.auth.tokenStorageKey);
+      if (!token) return;
+
+      const scheduleTokenRefresh = (tokenToUse: string) => {
+        const pl = decodeJwtPayload(tokenToUse);
+        if (!pl || !pl.exp) {
+          // fallback to interval-based refresh
+          if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current);
+          refreshTimerRef.current = setTimeout(
+            async () => {
+              const newToken = await refreshAuthToken();
+              if (newToken) {
+                await checkAuth(true);
+                scheduleTokenRefresh(newToken);
+              }
+            },
+            25 * 60 * 1000,
+          );
+          return;
+        }
+
+        const expMs = pl.exp * 1000;
+        const nowMs = Date.now();
+        const refreshBeforeMs = 60 * 1000; // refresh 1 minute before expiry
+        const msUntilRefresh = expMs - nowMs - refreshBeforeMs;
+
+        if (msUntilRefresh <= 0) {
+          (async () => {
+            const newToken = await refreshAuthToken();
+            if (newToken) {
+              await checkAuth(true);
+              // schedule based on the new token
+              scheduleTokenRefresh(newToken);
+            } else {
+              setUser(null);
+              clearAuthToken();
+              router.replace("/login");
+            }
+          })();
+        } else {
+          if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current);
+          refreshTimerRef.current = setTimeout(async () => {
+            const newToken = await refreshAuthToken();
+            if (newToken) {
+              await checkAuth(true);
+              scheduleTokenRefresh(newToken);
+            } else {
+              setUser(null);
+              clearAuthToken();
+              router.replace("/login");
+            }
+          }, msUntilRefresh);
+        }
+      };
+
+      const payload = decodeJwtPayload(token);
+      if (!payload || !payload.exp) {
+        scheduleTokenRefresh(token);
+        return;
+      }
+
+      scheduleTokenRefresh(token);
 
       return () => {
         if (refreshTimerRef.current) {
-          clearInterval(refreshTimerRef.current);
+          clearTimeout(refreshTimerRef.current);
+          refreshTimerRef.current = null;
         }
       };
     }
-  }, [user, checkAuth]);
+  }, [user, checkAuth, router]);
 
   // 只在初始載入時檢查一次
   useEffect(() => {
@@ -137,15 +200,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     // 清除刷新計時器
     if (refreshTimerRef.current) {
-      clearInterval(refreshTimerRef.current);
+      clearTimeout(refreshTimerRef.current);
     }
 
     // Remove tokens and user info from both storages
     if (typeof window !== "undefined") {
-      localStorage.removeItem("token");
-      sessionStorage.removeItem("token");
-      localStorage.removeItem("user");
-      sessionStorage.removeItem("user");
+      localStorage.removeItem(appConfig.auth.tokenStorageKey);
+      sessionStorage.removeItem(appConfig.auth.tokenStorageKey);
+      localStorage.removeItem(appConfig.auth.userStorageKey);
+      sessionStorage.removeItem(appConfig.auth.userStorageKey);
     }
     router.replace("/login");
   };

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -105,6 +105,82 @@ export function loadAuthTokenFromStorage() {
 }
 
 /**
+ * Decode JWT payload without verification to read expiry time.
+ * This is safe within the client to just read exp claim for scheduling refreshes.
+ */
+export function decodeJwtPayload(token: string | null) {
+  if (!token) return null;
+  try {
+    const parts = token.split(".");
+    if (parts.length < 2) return null;
+    const payload = parts[1];
+    // base64url -> base64
+    const b64 = payload.replace(/-/g, "+").replace(/_/g, "/");
+    // decode base64 to UTF-8 string safely
+    const decoded = atob(b64);
+    const percentEncoded = decoded
+      .split("")
+      .map((c) => `%${(`00${c.charCodeAt(0).toString(16)}`).slice(-2)}`)
+      .join("");
+    const json = JSON.parse(decodeURIComponent(percentEncoded));
+    return json as { exp?: number };
+  } catch (err) {
+    console.warn("Failed to decode JWT payload:", err);
+    return null;
+  }
+}
+
+/**
+ * Call backend refresh endpoint to renew the access token.
+ * Returns the new token or null if refresh fails.
+ */
+export async function refreshAuthToken(): Promise<string | null> {
+  const token =
+    typeof window !== "undefined"
+      ? localStorage.getItem(appConfig.auth.tokenStorageKey) ||
+        sessionStorage.getItem(appConfig.auth.tokenStorageKey)
+      : null;
+
+  if (!token) return null;
+
+  try {
+    const res = await fetch(`${API_BASE_URL}/auth/refresh`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      // body: not needed - backend reads token from Authorization header
+    });
+
+    if (!res.ok) {
+      // Refresh failed; likely token invalid or expired
+      clearAuthToken();
+      return null;
+    }
+
+    const data = await res.json();
+    if (data?.access_token) {
+      // Persist and set the new token
+      if (typeof window !== "undefined") {
+        localStorage.setItem(appConfig.auth.tokenStorageKey, data.access_token);
+        sessionStorage.setItem(
+          appConfig.auth.tokenStorageKey,
+          data.access_token,
+        );
+      }
+      setAuthToken(data.access_token);
+      return data.access_token;
+    }
+    return null;
+  } catch (err) {
+    console.error("Token refresh failed:", err);
+    clearAuthToken();
+    return null;
+  }
+}
+
+/**
  * 處理 API 錯誤
  * 統一處理 401 錯誤
  */


### PR DESCRIPTION
This pull request introduces a robust JWT token refresh mechanism for both backend and frontend, improving authentication reliability and user experience. The backend now provides a dedicated endpoint for refreshing tokens, while the frontend schedules token refreshes based on actual expiry, reducing the risk of users being logged out unexpectedly.

**Backend enhancements:**

* Added `extract_jwt_token` to `app.core.security` and implemented a new `/auth/refresh` endpoint in `backend/app/auth/routes.py` that issues a new access token if the current one is still valid, returning 401 if expired. [[1]](diffhunk://#diff-ffc1c1711c50cfdce22e606d22460dba4ca4e38793b088e3bec4fd0d64844d84L8-R8) [[2]](diffhunk://#diff-ffc1c1711c50cfdce22e606d22460dba4ca4e38793b088e3bec4fd0d64844d84R41-R58)

**Frontend improvements:**

* Implemented `decodeJwtPayload` and `refreshAuthToken` in `frontend/lib/api.ts` to decode JWT expiry and call the backend refresh endpoint, updating stored tokens as needed.
* Refactored the token refresh logic in `AuthProvider` (`frontend/components/auth/auth-provider.tsx`) to schedule refreshes precisely before expiry using the decoded expiry time, with fallback to interval-based refresh if expiry is unavailable.
* Updated token and user info clearing logic to use keys from `appConfig`, ensuring consistency and maintainability.

These changes collectively ensure smoother authentication flows and minimize disruptions due to token expiry.